### PR TITLE
feat(bl6): add declared_effects workflow-level block (v8.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to hiivmind-blueprint-lib will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.0] - 2026-04-17
+
+### Added
+- `declared_effects:` optional workflow-level block (BL6). Per-alias narrowing of the default inferred effect envelope from `data_mcps`. Each alias value is either the string literal `forbidden` or an object with optional `tools: [...]` and `max_call_count: N`. Unknown keys under the alias object are reserved for future vocabulary and accepted today without effect. Cross-alias validation (tools subset, alias ∈ `data_mcps`) is delegated to the consuming runtime.
+- New `## Declared Effects` top-level section in `blueprint-types.md`.
+- Fixtures: `tests/fixtures/workflows/v8_declared_effects_{narrow,forbidden,unknown_key}/` (positive); `tests/fixtures/workflows/_negative/declared_effects_{bad_value,bad_alias_name,negative_max_count}/` (negative).
+
+### Changed
+- `schema/authoring/workflow.json` bumped to schema version 4.1 (purely additive — omitting the new block preserves 8.0.0 behavior exactly).
+- `examples.md` example §4 (`MCP-Delegated Query`) extended with a `declared_effects:` block.
+
+### Cross-repo sync
+- `hiivmind-blueprint/lib/patterns/authoring-guide.md` documents the new block.
+- `hiivmind-blueprint/lib/patterns/execution-guide.md` notes that load-time envelope enforcement is the consuming runtime's responsibility.
+
+### Migration
+- None. v8.0.0 workflows remain valid under v8.1.0 unchanged.
+
 ## [8.0.0] - 2026-04-17
 
 ### Added

--- a/blueprint-types.md
+++ b/blueprint-types.md
@@ -290,3 +290,41 @@ types; instances travel with the workflow.
 - Blueprint-lib does NOT validate that a consequence's `params` block conforms to the
   referenced payload type's field list — that is runtime concern. Blueprint-lib only
   validates that the reference resolves.
+
+## Declared Effects
+
+Optional workflow-level block narrowing the default inferred effect envelope
+from `data_mcps`. Workflows that omit the block accept any tool exposed by any
+declared alias, invoked arbitrarily many times. Authors who want fine-grained
+control add a `declared_effects:` block at the top level of the workflow YAML.
+
+Each key is an alias (same naming rules as `data_mcps`); each value is either:
+
+| Value form | Meaning |
+|---|---|
+| `forbidden` | Explicit deny — alias MUST NOT be invoked from this workflow. Readable documentation even when the alias is absent from `data_mcps`. |
+| `{ tools: [...] }` | Restrict to a subset of the MCP's tools. Unlisted tools are forbidden. |
+| `{ tools: [...], max_call_count: N }` | As above, with a hard cap on total invocations of this alias across a workflow run. |
+| `{ max_call_count: N }` | Cap invocations without narrowing the tool list. |
+
+### Example
+
+    data_mcps:
+      crm:     "internal-crm@^2.1"
+      billing: "stripe-mcp@~3"
+
+    declared_effects:
+      crm:
+        tools: [search_customers, get_account]
+      billing:
+        tools: [create_invoice]
+        max_call_count: 1
+      shell: forbidden
+
+### Load-time contract (enforced by downstream runtimes)
+
+- Aliases that appear in `declared_effects` with an object value MUST also appear in `data_mcps`.
+- Each entry in `tools` MUST be a tool exported by the aliased MCP server.
+- `max_call_count` is interpreted as a static upper bound across all reachable paths through the workflow DAG.
+- Unknown keys under an alias object are reserved for future vocabulary (data volume caps, time windows, resource classes) and are accepted today without effect.
+- Blueprint-lib validates only the syntactic shape of the block; cross-alias and cross-server checks are the consuming runtime's concern.

--- a/docs/superpowers/plans/2026-04-17-bl6-declared-effects.md
+++ b/docs/superpowers/plans/2026-04-17-bl6-declared-effects.md
@@ -1,0 +1,692 @@
+# BL6 `declared_effects` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the optional top-level `declared_effects:` block to the blueprint-lib workflow schema, shipped as v8.1.0.
+
+**Architecture:** Purely additive change. One new optional property on `workflow.json`; catalog documentation in `blueprint-types.md`; extended worked example in `examples.md`; three positive + three negative fixtures; cross-repo sync to `hiivmind-blueprint` authoring/execution guides.
+
+**Tech Stack:** JSON Schema Draft 2020-12 (`ajv-cli@5` validator), YAML fixtures (`yq`), Bash test runners (`scripts/validate-workflows.sh`).
+
+---
+
+## Spec
+
+`docs/superpowers/specs/2026-04-17-bl6-declared-effects-design.md`
+
+## Working branch
+
+`feat/bl6-declared-effects` (already created off `develop`, spec already committed as `41a6ee7`).
+
+## Target
+
+`develop` (blueprint-lib follows `develop → release/* → main` flow).
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `schema/authoring/workflow.json` | New optional property `declared_effects`; bump `$comment` schema-version note. |
+| `blueprint-types.md` | New `## Declared Effects` top-level section (parallel to `## Payload Types`). |
+| `examples.md` | Extend `## 4. MCP-Delegated Query` worked example with a `declared_effects:` block. |
+| `tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml` | Positive: narrowed envelope with `tools` + `max_call_count`. |
+| `tests/fixtures/workflows/v8_declared_effects_forbidden/input.yaml` | Positive: `alias: forbidden` literal (declared + undeclared aliases). |
+| `tests/fixtures/workflows/v8_declared_effects_unknown_key/input.yaml` | Positive: forward-compat extension keys under alias object. |
+| `tests/fixtures/workflows/_negative/declared_effects_bad_value/input.yaml` | Negative: alias value neither object nor `"forbidden"`. |
+| `tests/fixtures/workflows/_negative/declared_effects_bad_alias_name/input.yaml` | Negative: alias fails `propertyNames` pattern. |
+| `tests/fixtures/workflows/_negative/declared_effects_negative_max_count/input.yaml` | Negative: `max_call_count: -1`. |
+| `package.yaml` | Version bump 8.0.0 → 8.1.0; `schemas.workflow: "4.0"` → `"4.1"`. |
+| `CHANGELOG.md` | New `[8.1.0] - 2026-04-17` entry. |
+| `../hiivmind-blueprint/lib/patterns/authoring-guide.md` | New `declared_effects` subsection. |
+| `../hiivmind-blueprint/lib/patterns/execution-guide.md` | One-paragraph note delegating envelope enforcement to the consuming runtime. |
+
+---
+
+## Task 1: Write the first positive fixture and confirm baseline rejection
+
+Before touching the schema, write a positive fixture that exercises the new key. Because `workflow.json` currently has `additionalProperties: false` at its root, the validator MUST reject it today — that's the baseline for TDD.
+
+**Files:**
+- Create: `tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml`
+
+- [ ] **Step 1: Create the positive fixture**
+
+Create `tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml`:
+
+```yaml
+name: declared-effects-narrow
+version: "1.0.0"
+description: Workflow with a narrowed effect envelope — tools subset plus call count cap.
+
+data_mcps:
+  crm: "internal-crm@^2.1"
+  billing: "stripe-mcp@~3"
+
+declared_effects:
+  crm:
+    tools: [search_customers, get_account]
+  billing:
+    tools: [create_invoice]
+    max_call_count: 1
+
+start_node: search
+default_error: error_generic
+
+nodes:
+  search:
+    type: action
+    consequences:
+      - type: mcp_tool_call
+        tool: crm.search_customers
+        params:
+          q: "${computed.query}"
+        store_as: computed.hits
+    on_success: done
+
+  done:
+    type: ending
+    outcome: success
+    message: "Done."
+
+  error_generic:
+    type: ending
+    outcome: error
+    message: "Error."
+```
+
+- [ ] **Step 2: Run validator to verify it FAILS at baseline**
+
+Run: `bash scripts/validate-workflows.sh`
+
+Expected: `FAIL  tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml` with an `additionalProperties` error naming `declared_effects`. Exit code `1`.
+
+This confirms the schema currently rejects the key — exactly what we expect before the schema change.
+
+- [ ] **Step 3: Commit the fixture (without schema change)**
+
+```bash
+git add tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml
+git commit -m "test(bl6): positive fixture for narrowed declared_effects envelope"
+```
+
+The commit intentionally leaves the suite failing — Task 2 fixes it.
+
+---
+
+## Task 2: Add `declared_effects` to workflow.json schema
+
+**Files:**
+- Modify: `schema/authoring/workflow.json`
+
+- [ ] **Step 1: Add the property and bump the `$comment`**
+
+Edit `schema/authoring/workflow.json`. Change line 4:
+
+```json
+"$comment": "Schema version 4.0 - Added trust_mode, data_mcps, payload_types (BL2/BL3/BL4); ending nodes live in nodes: (BL5).",
+```
+
+to:
+
+```json
+"$comment": "Schema version 4.1 - BL6: added optional top-level declared_effects block (effect envelope narrowing).",
+```
+
+Then, inside `#/properties`, insert the following property between `payload_types` (ends around line 42 with `}`) and `entry_preconditions`:
+
+```json
+    "declared_effects": {
+      "type": "object",
+      "description": "Optional per-alias effect envelope narrowing the inferred default from data_mcps (BL6). Keys are aliases declared in data_mcps (or unused aliases used as forbidden documentation). Values are either the string literal 'forbidden' or an object with optional 'tools' and 'max_call_count'. Cross-alias validation (tools subset, alias-in-data_mcps) is delegated to the consuming runtime.",
+      "propertyNames": { "pattern": "^[a-z_][a-z0-9_-]*$" },
+      "additionalProperties": {
+        "oneOf": [
+          { "const": "forbidden" },
+          {
+            "type": "object",
+            "properties": {
+              "tools": {
+                "type": "array",
+                "items": { "type": "string", "pattern": "^[a-z_][a-z0-9_]*$" },
+                "uniqueItems": true,
+                "description": "Allowed tool names on this alias. Subset of the data-MCP's published tools (runtime-checked)."
+              },
+              "max_call_count": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Hard cap on invocations of this alias per workflow run (static upper bound)."
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
+      }
+    },
+```
+
+- [ ] **Step 2: Verify the schema is still valid JSON**
+
+Run: `jq . schema/authoring/workflow.json > /dev/null`
+
+Expected: no output, exit code `0`. (Any parse error prints a message.)
+
+- [ ] **Step 3: Run validator to verify the positive fixture now PASSES**
+
+Run: `bash scripts/validate-workflows.sh`
+
+Expected: `OK    tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml`. Positive count increases by one compared to Task 1's baseline; all previously-passing fixtures still pass. Exit code `0` (assuming no other failures).
+
+- [ ] **Step 4: Commit the schema change**
+
+```bash
+git add schema/authoring/workflow.json
+git commit -m "feat(bl6): add declared_effects property to workflow schema"
+```
+
+---
+
+## Task 3: Add remaining positive fixtures
+
+**Files:**
+- Create: `tests/fixtures/workflows/v8_declared_effects_forbidden/input.yaml`
+- Create: `tests/fixtures/workflows/v8_declared_effects_unknown_key/input.yaml`
+
+- [ ] **Step 1: Create the `forbidden` fixture**
+
+Create `tests/fixtures/workflows/v8_declared_effects_forbidden/input.yaml`:
+
+```yaml
+name: declared-effects-forbidden
+version: "1.0.0"
+description: Workflow explicitly forbidding two aliases — one declared in data_mcps, one documentation-only.
+
+data_mcps:
+  crm: "internal-crm@^2"
+
+declared_effects:
+  crm: forbidden
+  shell: forbidden
+
+start_node: done
+default_error: done
+
+nodes:
+  done:
+    type: ending
+    outcome: success
+    message: "Done."
+```
+
+- [ ] **Step 2: Create the `unknown_key` fixture**
+
+Create `tests/fixtures/workflows/v8_declared_effects_unknown_key/input.yaml`:
+
+```yaml
+name: declared-effects-unknown-key
+version: "1.0.0"
+description: Forward-compat — unknown keys under an alias object are accepted (reserved for future vocabulary).
+
+data_mcps:
+  crm: "internal-crm@^2"
+
+declared_effects:
+  crm:
+    tools: [search_customers]
+    data_volume_cap_mb: 100
+    time_window_sec: 60
+
+start_node: done
+default_error: done
+
+nodes:
+  done:
+    type: ending
+    outcome: success
+    message: "Done."
+```
+
+- [ ] **Step 3: Run validator to verify both PASS**
+
+Run: `bash scripts/validate-workflows.sh`
+
+Expected: Both new fixtures appear as `OK`. Positive count increases by two. Exit code `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/fixtures/workflows/v8_declared_effects_forbidden/input.yaml \
+        tests/fixtures/workflows/v8_declared_effects_unknown_key/input.yaml
+git commit -m "test(bl6): positive fixtures for forbidden literal and unknown-key forward-compat"
+```
+
+---
+
+## Task 4: Add negative fixtures
+
+**Files:**
+- Create: `tests/fixtures/workflows/_negative/declared_effects_bad_value/input.yaml`
+- Create: `tests/fixtures/workflows/_negative/declared_effects_bad_alias_name/input.yaml`
+- Create: `tests/fixtures/workflows/_negative/declared_effects_negative_max_count/input.yaml`
+
+- [ ] **Step 1: Create the bad-value fixture**
+
+Create `tests/fixtures/workflows/_negative/declared_effects_bad_value/input.yaml`:
+
+```yaml
+# NEGATIVE: declared_effects value must be either "forbidden" string or an object.
+name: bad-declared-effect-value
+version: "1.0.0"
+start_node: done
+default_error: done
+
+declared_effects:
+  crm: true
+
+nodes:
+  done:
+    type: ending
+    outcome: success
+```
+
+- [ ] **Step 2: Create the bad-alias-name fixture**
+
+Create `tests/fixtures/workflows/_negative/declared_effects_bad_alias_name/input.yaml`:
+
+```yaml
+# NEGATIVE: declared_effects alias names must match ^[a-z_][a-z0-9_-]*$ — 'CRM' is uppercase.
+name: bad-declared-effect-alias
+version: "1.0.0"
+start_node: done
+default_error: done
+
+declared_effects:
+  CRM:
+    tools: [search_customers]
+
+nodes:
+  done:
+    type: ending
+    outcome: success
+```
+
+- [ ] **Step 3: Create the negative-max-count fixture**
+
+Create `tests/fixtures/workflows/_negative/declared_effects_negative_max_count/input.yaml`:
+
+```yaml
+# NEGATIVE: max_call_count must be >= 0.
+name: bad-declared-effect-max-count
+version: "1.0.0"
+start_node: done
+default_error: done
+
+data_mcps:
+  crm: "internal-crm@^2"
+
+declared_effects:
+  crm:
+    max_call_count: -1
+
+nodes:
+  done:
+    type: ending
+    outcome: success
+```
+
+- [ ] **Step 4: Run validator to verify all three are correctly rejected**
+
+Run: `bash scripts/validate-workflows.sh`
+
+Expected: Each of the three appears as `OK ... (correctly rejected)` in the negative section. Exit code `0`. Final summary line: "All workflow fixtures OK".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/workflows/_negative/declared_effects_bad_value/input.yaml \
+        tests/fixtures/workflows/_negative/declared_effects_bad_alias_name/input.yaml \
+        tests/fixtures/workflows/_negative/declared_effects_negative_max_count/input.yaml
+git commit -m "test(bl6): negative fixtures for bad value, bad alias name, negative max_call_count"
+```
+
+---
+
+## Task 5: Add `## Declared Effects` section to `blueprint-types.md`
+
+**Files:**
+- Modify: `blueprint-types.md` (append a new top-level section immediately after `## Payload Types`, which ends around line 293)
+
+- [ ] **Step 1: Add the new section**
+
+Open `blueprint-types.md`. The existing `## Payload Types` section ends at line 293 (`- Blueprint-lib does NOT validate...runtime concern...`). Immediately after that line, add a blank line then the following new section:
+
+```markdown
+
+## Declared Effects
+
+Optional workflow-level block narrowing the default inferred effect envelope
+from `data_mcps`. Workflows that omit the block accept any tool exposed by any
+declared alias, invoked arbitrarily many times. Authors who want fine-grained
+control add a `declared_effects:` block at the top level of the workflow YAML.
+
+Each key is an alias (same naming rules as `data_mcps`); each value is either:
+
+| Value form | Meaning |
+|---|---|
+| `forbidden` | Explicit deny — alias MUST NOT be invoked from this workflow. Readable documentation even when the alias is absent from `data_mcps`. |
+| `{ tools: [...] }` | Restrict to a subset of the MCP's tools. Unlisted tools are forbidden. |
+| `{ tools: [...], max_call_count: N }` | As above, with a hard cap on total invocations of this alias across a workflow run. |
+| `{ max_call_count: N }` | Cap invocations without narrowing the tool list. |
+
+### Example
+
+    data_mcps:
+      crm:     "internal-crm@^2.1"
+      billing: "stripe-mcp@~3"
+
+    declared_effects:
+      crm:
+        tools: [search_customers, get_account]
+      billing:
+        tools: [create_invoice]
+        max_call_count: 1
+      shell: forbidden
+
+### Load-time contract (enforced by downstream runtimes)
+
+- Aliases that appear in `declared_effects` with an object value MUST also appear in `data_mcps`.
+- Each entry in `tools` MUST be a tool exported by the aliased MCP server.
+- `max_call_count` is interpreted as a static upper bound across all reachable paths through the workflow DAG.
+- Unknown keys under an alias object are reserved for future vocabulary (data volume caps, time windows, resource classes) and are accepted today without effect.
+- Blueprint-lib validates only the syntactic shape of the block; cross-alias and cross-server checks are the consuming runtime's concern.
+```
+
+- [ ] **Step 2: Verify no Markdown structure damage**
+
+Run: `grep -n '^## ' blueprint-types.md`
+
+Expected output includes (in order): `## Conventions`, `## Nodes`, `## Preconditions`, `## Consequences`, `## Payload Types`, `## Declared Effects`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add blueprint-types.md
+git commit -m "docs(bl6): add '## Declared Effects' section to blueprint-types.md"
+```
+
+---
+
+## Task 6: Extend `## 4. MCP-Delegated Query` example in `examples.md`
+
+**Files:**
+- Modify: `examples.md:573-584` (update the "New in v8" note and add a `declared_effects:` block to the embedded YAML)
+
+- [ ] **Step 1: Update the "New in v8" hint and add the block**
+
+Open `examples.md`. Find the section starting at line 566. Replace the single line at 573:
+
+```markdown
+**New in v8:** workflow-level `trust_mode`, `data_mcps`, `payload_types`.
+```
+
+with:
+
+```markdown
+**New in v8:** workflow-level `trust_mode`, `data_mcps`, `payload_types`, `declared_effects`.
+```
+
+Then, inside the YAML code fence that starts at line 575, insert a `declared_effects:` block directly after the `data_mcps:` block. The existing `data_mcps:` block is:
+
+```yaml
+data_mcps:
+  eightball: "eightball-tools@^1"
+```
+
+Change the sequence from `data_mcps → payload_types` to `data_mcps → declared_effects → payload_types`. The inserted block (and one trailing blank line) is:
+
+```yaml
+declared_effects:
+  eightball:
+    tools: [shake]
+    max_call_count: 1
+```
+
+The surrounding YAML becomes:
+
+```yaml
+data_mcps:
+  eightball: "eightball-tools@^1"
+
+declared_effects:
+  eightball:
+    tools: [shake]
+    max_call_count: 1
+
+payload_types:
+  shake_params@1:
+    question: string (min_length=1)
+    context:  string (optional)
+```
+
+- [ ] **Step 2: Verify example YAML still parses**
+
+Run: `awk '/^````yaml$/,/^````$/' examples.md | sed '1d;$d' | yq -o=json '.' > /dev/null`
+
+Expected: no output, exit code `0`. (Only the first fenced YAML block is extracted; if the file has multiple, this check only covers the first. The §4 example is the last, so for full coverage run the extraction per section manually or rely on `validate-workflows.sh` for fixture coverage. The schema-level check happens in Task 7.)
+
+If the command above does not target §4, use this targeted extraction instead:
+
+```bash
+sed -n '/^## 4. MCP-Delegated Query/,$p' examples.md | awk '/^````yaml$/,/^````$/' | sed '1d;$d' | yq -o=json '.' > /dev/null
+```
+
+Expected: no output, exit code `0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples.md
+git commit -m "docs(bl6): extend MCP-Delegated Query example with declared_effects"
+```
+
+---
+
+## Task 7: Bump version and add CHANGELOG entry
+
+**Files:**
+- Modify: `package.yaml:5` (version) and `package.yaml:23` (schemas.workflow)
+- Modify: `CHANGELOG.md` (insert new entry at the top)
+
+- [ ] **Step 1: Bump version in `package.yaml`**
+
+Edit `package.yaml`. Change line 5:
+
+```yaml
+version: "8.0.0"
+```
+
+to:
+
+```yaml
+version: "8.1.0"
+```
+
+And change line 23:
+
+```yaml
+  workflow: "4.0"
+```
+
+to:
+
+```yaml
+  workflow: "4.1"
+```
+
+Stats lines (27-33) remain unchanged — BL6 adds no new types.
+
+- [ ] **Step 2: Verify `package.yaml` still parses**
+
+Run: `yq -o=json '.' package.yaml > /dev/null`
+
+Expected: no output, exit code `0`.
+
+- [ ] **Step 3: Insert the `[8.1.0]` changelog entry**
+
+Open `CHANGELOG.md`. Locate the line `## [8.0.0] - 2026-04-17`. Insert the following block immediately before it (leaving the `[8.0.0]` section intact):
+
+```markdown
+## [8.1.0] - 2026-04-17
+
+### Added
+- `declared_effects:` optional workflow-level block (BL6). Per-alias narrowing of the default inferred effect envelope from `data_mcps`. Each alias value is either the string literal `forbidden` or an object with optional `tools: [...]` and `max_call_count: N`. Unknown keys under the alias object are reserved for future vocabulary and accepted today without effect. Cross-alias validation (tools subset, alias ∈ `data_mcps`) is delegated to the consuming runtime.
+- New `## Declared Effects` top-level section in `blueprint-types.md`.
+- Fixtures: `tests/fixtures/workflows/v8_declared_effects_{narrow,forbidden,unknown_key}/` (positive); `tests/fixtures/workflows/_negative/declared_effects_{bad_value,bad_alias_name,negative_max_count}/` (negative).
+
+### Changed
+- `schema/authoring/workflow.json` bumped to schema version 4.1 (purely additive — omitting the new block preserves 8.0.0 behavior exactly).
+- `examples.md` example §4 (`MCP-Delegated Query`) extended with a `declared_effects:` block.
+
+### Cross-repo sync
+- `hiivmind-blueprint/lib/patterns/authoring-guide.md` documents the new block.
+- `hiivmind-blueprint/lib/patterns/execution-guide.md` notes that load-time envelope enforcement is the consuming runtime's responsibility.
+
+### Migration
+- None. v8.0.0 workflows remain valid under v8.1.0 unchanged.
+
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.yaml CHANGELOG.md
+git commit -m "chore(bl6): bump version to 8.1.0 and document in CHANGELOG"
+```
+
+---
+
+## Task 8: Cross-repo sync — `hiivmind-blueprint` pattern guides
+
+**Files:**
+- Modify: `../hiivmind-blueprint/lib/patterns/authoring-guide.md` (append new subsection in the "Workflow-level declarations (v8)" area, around line 557-575)
+- Modify: `../hiivmind-blueprint/lib/patterns/execution-guide.md` (append one-paragraph note near the `mcp_tool_call` execution section, around line 396-412)
+
+- [ ] **Step 1: Add authoring subsection to `authoring-guide.md`**
+
+Open `../hiivmind-blueprint/lib/patterns/authoring-guide.md`. Locate line 563:
+
+```markdown
+- **`payload_types`** (BL2) — see Payload Types section above.
+```
+
+Insert this new bullet immediately after it:
+
+```markdown
+- **`declared_effects`** (BL6, v8.1+) — optional per-alias effect envelope narrowing. Each alias maps to either the string literal `forbidden` or an object with optional `tools: [...]` and `max_call_count: N`. Cross-alias enforcement (tools-subset, alias-declared-in-`data_mcps`) is the consuming runtime's job; blueprint-lib validates only the syntactic shape.
+```
+
+Then, after the existing "Example front-matter" block (which ends at line 575 with ` }`), insert a new `####` heading and an extended example:
+
+```markdown
+
+#### Narrowing the effect envelope (`declared_effects`)
+
+Workflows that declare `data_mcps` accept any exported tool on any declared
+alias by default. To narrow that envelope — useful for sensitive workflows or
+for producing a machine-readable "effect manifest" — add a `declared_effects:`
+block:
+
+```yaml
+data_mcps:
+  crm:     "internal-crm@^2.1"
+  billing: "stripe-mcp@~3"
+
+declared_effects:
+  crm:
+    tools: [search_customers, get_account]   # read-only subset
+  billing:
+    tools: [create_invoice]
+    max_call_count: 1                        # hard cap across workflow run
+  shell: forbidden                           # explicit deny (documentation)
+```
+
+Over-declaration (listing tools the workflow never calls) is a warning from the
+consuming runtime, not an error — authors can narrow progressively during
+hardening.
+```
+
+- [ ] **Step 2: Add execution note to `execution-guide.md`**
+
+Open `../hiivmind-blueprint/lib/patterns/execution-guide.md`. Locate the `### Executing mcp_tool_call consequences` section (around line 396). After that section's last paragraph (before the next `###` heading), add:
+
+```markdown
+
+#### Effect-envelope enforcement
+
+Workflows may declare an explicit `declared_effects:` block (BL6, v8.1+) to
+narrow the default envelope inferred from `data_mcps`. Enforcement is a
+load-time static check, the consuming runtime's responsibility:
+
+- Reject any `mcp_tool_call` whose `tool` is not in the narrowed allowlist
+  (`tool_outside_envelope`).
+- Reject workflows whose reachable invocation count for an alias exceeds a
+  declared `max_call_count` (`count_exceeds_envelope`).
+- Warn on over-declaration (declared tools never invoked); not an error.
+
+Blueprint-lib validates only the block's syntactic shape. `declared_effects`
+narrows the envelope but does not widen it — cross-referencing against the
+aliased MCP server's published tools happens at the runtime boundary.
+```
+
+- [ ] **Step 3: Commit in the blueprint repo**
+
+```bash
+cd ../hiivmind-blueprint
+git checkout -b sync/bl6-declared-effects
+git add lib/patterns/authoring-guide.md lib/patterns/execution-guide.md
+git commit -m "docs(bl6): document declared_effects block in authoring + execution guides
+
+Cross-repo sync for hiivmind-blueprint-lib v8.1.0 BL6 addition. Authoring
+guide gets a new declared_effects subsection under 'Workflow-level
+declarations (v8)'; execution guide gets an 'Effect-envelope enforcement'
+subsection under the mcp_tool_call executor notes.
+
+Cross-ref: hiivmind-blueprint-lib spec
+docs/superpowers/specs/2026-04-17-bl6-declared-effects-design.md"
+cd ../hiivmind-blueprint-lib
+```
+
+(The blueprint repo PR is opened separately after the lib PR merges and tags v8.1.0.)
+
+---
+
+## Self-review results
+
+**1. Spec coverage:**
+- Schema property addition → Task 2 ✓
+- Schema shape with three value forms + `additionalProperties: true` on alias object → Task 2 ✓
+- Catalog entry (`## Declared Effects` new top-level section) → Task 5 ✓
+- `examples.md` §4 extension → Task 6 ✓
+- CHANGELOG entry → Task 7 ✓
+- package.yaml version bump → Task 7 ✓
+- 3 positive fixtures → Tasks 1 + 3 ✓
+- 3 negative fixtures → Task 4 ✓
+- Cross-repo sync (authoring + execution guides) → Task 8 ✓
+- `$comment` schema-version bump → Task 2 ✓
+
+No gaps.
+
+**2. Placeholder scan:** No TBDs, TODOs, "add appropriate X", "handle edge cases", or "similar to Task N" references. Every step has concrete code, paths, and commands.
+
+**3. Type consistency:**
+- Property name `declared_effects` — consistent across schema, catalog, example, CHANGELOG, authoring guide, execution guide, all fixtures.
+- Value-form enumeration — `forbidden` literal + `{tools}` / `{tools, max_call_count}` / `{max_call_count}` — consistent across Task 2 schema, Task 5 catalog, Task 7 CHANGELOG, Task 8 authoring guide.
+- Alias naming pattern `^[a-z_][a-z0-9_-]*$` — present in Task 2 schema, referenced in Task 5 catalog ("same naming rules as `data_mcps`"), asserted by Task 4's `bad_alias_name` fixture.
+- Tool naming pattern `^[a-z_][a-z0-9_]*$` — present in Task 2 schema only; fixtures use conforming names.
+
+---
+
+## Execution notes
+
+- `scripts/validate-workflows.sh` requires `npx` and `yq`; first run may download `ajv-cli@5` (a few seconds) via `npx --yes`. Pre-warm by running the validator once before dispatching implementer subagents if network latency is a concern.
+- Commits 1–7 run in blueprint-lib on `feat/bl6-declared-effects`. Commit 8 runs in `../hiivmind-blueprint` on a new branch `sync/bl6-declared-effects`. Both branches open independent PRs; lib PR merges first and tags v8.1.0, blueprint PR follows.
+- After the lib PR merges and v8.1.0 is tagged, open a small follow-up commit in `hiivmind-blueprint-central` flipping BL6's `Status: PROPOSED` to `SHIPPED` in the S1 addendum (lines 290 and 352–357). Not included in this plan; listed under "Sequencing" step 3 of the spec.

--- a/docs/superpowers/specs/2026-04-17-bl6-declared-effects-design.md
+++ b/docs/superpowers/specs/2026-04-17-bl6-declared-effects-design.md
@@ -1,0 +1,207 @@
+# BL6 — `declared_effects` Workflow-Level Block (v8.1.0)
+
+**Date:** 2026-04-17
+**Status:** DESIGN
+**Target version:** blueprint-lib v8.1.0 (minor, purely additive)
+**Source of truth:** hiivmind-blueprint-central commit `c13d65e`, S2 spec §3 — effect-envelope design.
+**Addendum reference:** hiivmind-blueprint-central `docs/superpowers/specs/2026-04-16-s1-blueprint-lib-alignment-addendum.md` lines 257, 261–306, 352–357.
+
+---
+
+## Goal
+
+Add the optional top-level `declared_effects:` block to the blueprint-lib workflow schema so authors can narrow the inferred `data_mcps` effect envelope on a per-alias basis. Unblocks S3 implementation in hiivmind-blueprint-central, which currently cannot ship because blueprint-lib's workflow schema rejects the key under its `additionalProperties: false` root.
+
+No existing type signature changes. No node-type changes. No behavior change for workflows that omit the block.
+
+## Background
+
+As of blueprint-lib v8.0.0 (shipped 2026-04-17) the workflow schema already carries BL1–BL5:
+
+- BL1: `mcp_tool_call` consequence
+- BL2: workflow-scoped `payload_types`
+- BL3: `trust_mode` enum
+- BL4: `data_mcps` alias→`name@semver` map
+- BL5: `ending` node primitive (replaces the `terminal_nodes` list originally proposed)
+
+S2 §3 defines a hybrid effect-envelope model:
+
+- **Default envelope** is *inferred* from `data_mcps`: "any tool exposed by any declared MCP may be invoked, arbitrarily often." Zero author burden. Already supported in v8.0.0.
+- **Explicit `declared_effects:`** narrows the envelope per alias. **Not yet supported** — schema rejects the key.
+
+BL6 ships the explicit-narrowing surface.
+
+## Non-goals
+
+- Cross-alias validation (e.g. `tools ⊆ data_mcps.<alias>.tools`, `alias ∈ data_mcps`). JSON Schema cannot cross-reference across MCP servers; blueprint-lib delegates semantic validation to the consuming runtime (control-MCP), consistent with the `mcp_tool_call` model already in place.
+- Runtime effect budget tally (S2 §3.7 out-of-scope).
+- Reachability analysis / `static_max` computation (S2 §3.5 enforcement territory — control-MCP concern).
+- Richer envelope keys (data volume caps, time windows, resource classes per SS P7). Schema reserves unknown keys; these are future extensions.
+- Changing the default inferred envelope. Workflows without `declared_effects:` keep v8.0.0 semantics.
+
+## Deliverables
+
+| File | Change |
+|---|---|
+| `schema/authoring/workflow.json` | Add optional `declared_effects` property (schema shape below). Bump `$comment` version note. |
+| `blueprint-types.md` | Add a new `## Declared Effects` top-level section (parallel to the existing `## Payload Types` section) describing the block and its three value forms. |
+| `examples.md` | Extend the existing `## 4. MCP-Delegated Query` example with a `declared_effects:` block so the worked example exercises it. |
+| `CHANGELOG.md` | New `[8.1.0] - 2026-04-17` entry — Added only (no Changed / Fixed). |
+| `package.yaml` | Bump version to `8.1.0`. Stats unchanged (no new types). |
+| `tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml` | Positive fixture — explicit narrowed envelope. |
+| `tests/fixtures/workflows/v8_declared_effects_forbidden/input.yaml` | Positive fixture — `alias: forbidden` literal. |
+| `tests/fixtures/workflows/v8_declared_effects_unknown_key/input.yaml` | Positive fixture — forward-compat extension keys under an alias object. |
+| `tests/fixtures/workflows/_negative/declared_effects_bad_value/input.yaml` | Neither object nor `"forbidden"` string. |
+| `tests/fixtures/workflows/_negative/declared_effects_bad_alias_name/input.yaml` | Alias fails `^[a-z_][a-z0-9_-]*$`. |
+| `tests/fixtures/workflows/_negative/declared_effects_negative_max_count/input.yaml` | `max_call_count: -1`. |
+
+**Cross-repo sync** (required per `CLAUDE.md`'s hard-requirement checklist):
+
+| Location | Change |
+|---|---|
+| `hiivmind-blueprint/lib/patterns/authoring-guide.md` | Add `declared_effects:` subsection showing the three value forms; position alongside existing `trust_mode`/`data_mcps` authoring guidance. |
+| `hiivmind-blueprint/lib/patterns/execution-guide.md` | One-paragraph note stating load-time envelope enforcement is the control-MCP's responsibility, not blueprint-lib's — consistent with `mcp_tool_call`'s type-agnostic posture. |
+| `hiivmind-blueprint` skill bundle | Re-ship `blueprint-types.md` on next release. |
+
+**No sync needed** in `hiivmind-blueprint-central`: the addendum already documents BL6 at lines 261–306; only its `Status: PROPOSED` → `SHIPPED` note (line 290) and the `Pending upstream ship` resolution note (lines 352–357) need flipping. That flip happens as a separate blueprint-central commit after this PR merges.
+
+## Schema shape
+
+Added under `workflow.json#/properties`:
+
+```json
+"declared_effects": {
+  "type": "object",
+  "description": "Optional per-alias effect envelope narrowing the inferred default from data_mcps (BL6). Keys are aliases declared in data_mcps (or unused aliases used as forbidden documentation). Values are either the string literal 'forbidden' or an object with optional 'tools' and 'max_call_count'. Cross-alias validation (tools ⊆ data_mcps.<alias>.tools, alias ∈ data_mcps) is delegated to the consuming runtime.",
+  "propertyNames": { "pattern": "^[a-z_][a-z0-9_-]*$" },
+  "additionalProperties": {
+    "oneOf": [
+      { "const": "forbidden" },
+      {
+        "type": "object",
+        "properties": {
+          "tools": {
+            "type": "array",
+            "items": { "type": "string", "pattern": "^[a-z_][a-z0-9_]*$" },
+            "uniqueItems": true,
+            "description": "Allowed tool names on this alias. Subset of the data-MCP's published tools (runtime-checked)."
+          },
+          "max_call_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Hard cap on invocations of this alias per workflow run (static upper bound)."
+          }
+        },
+        "additionalProperties": true
+      }
+    ]
+  }
+}
+```
+
+### Design notes on the schema
+
+- **`additionalProperties: true` inside the alias object** — intentional. S2 §3.4 reserves unknown keys for forward-compatible extension (data volume caps, time windows, resource classes per SS P7). Schema accepts them today so v0 workflows don't break when v1 adds vocabulary.
+- **`max_call_count: 0` is valid** — equivalent to `forbidden` at the allowlist level but allows authors to keep the alias entry with its `tools: []` for documentation. Not conceptually different from `forbidden` in enforcement terms.
+- **`propertyNames` pattern on `declared_effects`** mirrors the pattern already in `data_mcps` (lines 31 of current `workflow.json`) so aliases have identical shape constraints.
+- **Alias name pattern for `tools` items** (`^[a-z_][a-z0-9_]*$`) matches MCP tool naming conventions — lowercase snake_case, no hyphens. Stricter than alias names because aliases are workflow-local labels whereas tool names are MCP-server-exported identifiers.
+
+## `blueprint-types.md` catalog entry (proposed content)
+
+New top-level section, placed immediately after `## Payload Types`:
+
+```markdown
+## Declared Effects
+
+Optional workflow-level block narrowing the default inferred effect envelope
+from `data_mcps`. Workflows that omit the block accept any tool exposed by any
+declared alias, invoked arbitrarily many times. Authors who want fine-grained
+control add a `declared_effects:` block at the top level of the workflow YAML.
+
+Each key is an alias (same naming rules as `data_mcps`); each value is either:
+
+| Value form | Meaning |
+|---|---|
+| `forbidden` | Explicit deny — alias MUST NOT be invoked from this workflow. Readable documentation even when the alias is absent from `data_mcps`. |
+| `{ tools: [...] }` | Restrict to a subset of the MCP's tools. Unlisted tools are forbidden. |
+| `{ tools: [...], max_call_count: N }` | As above, with a hard cap on total invocations across the workflow run. |
+| `{ max_call_count: N }` | Cap invocations without narrowing the tool list. |
+
+Cross-alias validation (is `<tool>` actually exported by the MCP? is the alias
+declared in `data_mcps`?) is enforced at workflow load time by the consuming
+runtime — blueprint-lib validates only the syntactic shape.
+```
+
+## Worked example (extension to `examples.md` §4)
+
+The existing `## 4. MCP-Delegated Query` example declares `data_mcps` for `crm` and `billing`. Extend it with:
+
+```yaml
+declared_effects:
+  crm:
+    tools: [search_customers, get_account]   # read-only subset
+  billing:
+    tools: [create_invoice]
+    max_call_count: 1                        # cap across workflow run
+  shell: forbidden                           # documentation — not in data_mcps
+```
+
+The prose around the example calls out that this block is optional and describes what each value form means. The pre-existing `mcp_tool_call` consequences in that example already invoke `crm.search_customers` / `billing.create_invoice`, so the narrowing is faithful to what the workflow actually does.
+
+## Fixtures
+
+### Positive
+
+- **`v8_declared_effects_narrow`** — full workflow declaring two aliases in `data_mcps` plus `declared_effects` with both `tools` and `max_call_count` on one, `tools` only on the other.
+- **`v8_declared_effects_forbidden`** — alias with value `forbidden` (both declared and undeclared aliases).
+- **`v8_declared_effects_unknown_key`** — alias object including a non-standard key (e.g. `data_volume_cap_mb: 100`) to confirm forward-compat acceptance.
+
+### Negative (must fail validation)
+
+- **`declared_effects_bad_value`** — alias set to `true` (neither object nor `"forbidden"` string).
+- **`declared_effects_bad_alias_name`** — alias like `CRM` or `billing-1!` that fails the `propertyNames` pattern.
+- **`declared_effects_negative_max_count`** — `max_call_count: -1`.
+
+## Validation
+
+`scripts/validate-workflows.sh` already exists from v8.0.0 and walks `tests/fixtures/workflows/`. New fixtures under that tree are picked up automatically. Negative fixtures under `_negative/` are expected to fail and counted as such.
+
+## Versioning
+
+v8.0.0 → v8.1.0 per `CLAUDE.md`'s versioning table: "Add new types → Minor." `declared_effects` is a new optional top-level field; omitting it is equivalent to prior behavior. No existing workflow breaks.
+
+`$comment` in `workflow.json` header bumps from "Schema version 4.0" to "Schema version 4.1" with a note about BL6.
+
+## Out of scope
+
+- Static reachability analysis or `count_exceeds_envelope` checks (S2 §3.5). Control-MCP concern.
+- `signature_status`, `illegal_state`, session-bound gated-mode machinery (S2 §§1, 4). Control-MCP concern.
+- Updating the S1/S2 addendum status notes in blueprint-central. Happens as a follow-up commit in that repo post-merge.
+- Tagging/releasing v8.1.0. Separate release step after merge to `develop`.
+
+## Risks
+
+- **Alias typo in `declared_effects` silently passes blueprint-lib schema.** Mitigation: control-MCP enforces `alias ∈ data_mcps OR value == "forbidden"` at load time. Documented as author contract in the catalog entry.
+- **Forward-compat trap: unknown keys under alias object are silently accepted today.** Authors who misspell a future key (`max_call_coutn: 3`) don't get a warning. Accepted risk — consistent with the spec §3.4 decision to reserve the keyspace.
+- **`max_call_count` interpretation ambiguity.** "Across workflow run" in S2 §3.4 means static upper bound summed across all reachable paths through the workflow DAG. Catalog entry states this explicitly so the control-MCP has a contract to enforce.
+
+## Sequencing
+
+1. Merge this BL6 PR to `hiivmind-blueprint-lib` develop, tag v8.1.0.
+2. Update `hiivmind-blueprint` authoring/execution guides (separate PR, tag when ready).
+3. In `hiivmind-blueprint-central`, flip `Status: PROPOSED` → `SHIPPED` in the S1 addendum and clear the resolution note at line 352.
+4. S3 implementation proceeds with the envelope surface available.
+
+---
+
+## Task breakdown (handoff to writing-plans)
+
+Seven tasks, all low-risk prose/schema/fixture edits:
+
+1. **Schema** — add `declared_effects` to `workflow.json`, bump header comment.
+2. **Catalog** — add subsection to `blueprint-types.md`.
+3. **Example** — extend `## 4. MCP-Delegated Query` in `examples.md`.
+4. **Fixtures** — three positive + three negative under `tests/fixtures/workflows/`.
+5. **Version + Changelog** — bump `package.yaml` to 8.1.0; add `[8.1.0]` entry.
+6. **Blueprint repo sync** — authoring-guide and execution-guide updates.
+7. **Verification** — run `scripts/validate-workflows.sh` and existing validators; spot-check a single fixture via ajv-cli.

--- a/examples.md
+++ b/examples.md
@@ -570,7 +570,7 @@ Ask the user for a question, invoke an external MCP tool, display the answer.
 **Types demonstrated:** `action`, `user_prompt`, `ending`, `mcp_tool_call`,
 `mutate_state`, `display`
 
-**New in v8:** workflow-level `trust_mode`, `data_mcps`, `payload_types`.
+**New in v8:** workflow-level `trust_mode`, `data_mcps`, `payload_types`, `declared_effects`.
 
 ````yaml
 name: mcp-delegated-query
@@ -581,6 +581,11 @@ trust_mode: stateless
 
 data_mcps:
   eightball: "eightball-tools@^1"
+
+declared_effects:
+  eightball:
+    tools: [shake]
+    max_call_count: 1
 
 payload_types:
   shake_params@1:

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@
 # Semantic type definitions for hiivmind-blueprint
 
 name: hiivmind-blueprint-lib
-version: "8.0.0"
+version: "8.1.0"
 description: |
   Single-file type catalog for hiivmind-blueprint. Defines 23 consequence
   types, 9 precondition types, and 4 node types (action, conditional,
@@ -19,7 +19,7 @@ license: MIT
 
 # Schema versions for each authoring system
 schemas:
-  workflow: "4.0"
+  workflow: "4.1"
   node: "4.0"
   payload_types: "1.0"
 

--- a/schema/authoring/workflow.json
+++ b/schema/authoring/workflow.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/hiivmind/hiivmind-blueprint-lib/main/schema/authoring/workflow.json",
-  "$comment": "Schema version 4.0 - Added trust_mode, data_mcps, payload_types (BL2/BL3/BL4); ending nodes live in nodes: (BL5).",
+  "$comment": "Schema version 4.1 - BL6: added optional top-level declared_effects block (effect envelope narrowing).",
   "title": "Blueprint Workflow Schema",
   "description": "JSON Schema for hiivmind-blueprint workflow.yaml files",
   "type": "object",
@@ -39,6 +39,33 @@
       "description": "Workflow-scoped payload type declarations (BL2). Keys are name@version; values are field maps. Referenced by consequences via params_type.",
       "propertyNames": { "pattern": "^[a-z_][a-z0-9_]*@\\d+$" },
       "additionalProperties": { "$ref": "payload-types.json#/$defs/payload_type" }
+    },
+    "declared_effects": {
+      "type": "object",
+      "description": "Optional per-alias effect envelope narrowing the inferred default from data_mcps (BL6). Keys are aliases declared in data_mcps (or unused aliases used as forbidden documentation). Values are either the string literal 'forbidden' or an object with optional 'tools' and 'max_call_count'. Cross-alias validation (tools subset, alias-in-data_mcps) is delegated to the consuming runtime.",
+      "propertyNames": { "pattern": "^[a-z_][a-z0-9_-]*$" },
+      "additionalProperties": {
+        "oneOf": [
+          { "const": "forbidden" },
+          {
+            "type": "object",
+            "properties": {
+              "tools": {
+                "type": "array",
+                "items": { "type": "string", "pattern": "^[a-z_][a-z0-9_]*$" },
+                "uniqueItems": true,
+                "description": "Allowed tool names on this alias. Subset of the data-MCP's published tools (runtime-checked)."
+              },
+              "max_call_count": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Hard cap on invocations of this alias per workflow run (static upper bound)."
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
+      }
     },
     "entry_preconditions": {
       "type": "array",

--- a/schema/authoring/workflow.json
+++ b/schema/authoring/workflow.json
@@ -42,7 +42,7 @@
     },
     "declared_effects": {
       "type": "object",
-      "description": "Optional per-alias effect envelope narrowing the inferred default from data_mcps (BL6). Keys are aliases declared in data_mcps (or unused aliases used as forbidden documentation). Values are either the string literal 'forbidden' or an object with optional 'tools' and 'max_call_count'. Cross-alias validation (tools subset, alias-in-data_mcps) is delegated to the consuming runtime.",
+      "description": "Optional per-alias effect envelope narrowing the inferred default from data_mcps (BL6). Keys are aliases declared in data_mcps (or unused aliases used as forbidden documentation). Values are either the string literal 'forbidden' or an object with optional 'tools' and 'max_call_count'. Cross-alias validation (tools ⊆ data_mcps.<alias>.tools, alias ∈ data_mcps) is delegated to the consuming runtime.",
       "propertyNames": { "pattern": "^[a-z_][a-z0-9_-]*$" },
       "additionalProperties": {
         "oneOf": [

--- a/tests/fixtures/workflows/_negative/declared_effects_bad_alias_name/input.yaml
+++ b/tests/fixtures/workflows/_negative/declared_effects_bad_alias_name/input.yaml
@@ -1,0 +1,14 @@
+# NEGATIVE: declared_effects alias names must match ^[a-z_][a-z0-9_-]*$ — 'CRM' is uppercase.
+name: bad-declared-effect-alias
+version: "1.0.0"
+start_node: done
+default_error: done
+
+declared_effects:
+  CRM:
+    tools: [search_customers]
+
+nodes:
+  done:
+    type: ending
+    outcome: success

--- a/tests/fixtures/workflows/_negative/declared_effects_bad_value/input.yaml
+++ b/tests/fixtures/workflows/_negative/declared_effects_bad_value/input.yaml
@@ -1,0 +1,13 @@
+# NEGATIVE: declared_effects value must be either "forbidden" string or an object.
+name: bad-declared-effect-value
+version: "1.0.0"
+start_node: done
+default_error: done
+
+declared_effects:
+  crm: true
+
+nodes:
+  done:
+    type: ending
+    outcome: success

--- a/tests/fixtures/workflows/_negative/declared_effects_negative_max_count/input.yaml
+++ b/tests/fixtures/workflows/_negative/declared_effects_negative_max_count/input.yaml
@@ -1,0 +1,17 @@
+# NEGATIVE: max_call_count must be >= 0.
+name: bad-declared-effect-max-count
+version: "1.0.0"
+start_node: done
+default_error: done
+
+data_mcps:
+  crm: "internal-crm@^2"
+
+declared_effects:
+  crm:
+    max_call_count: -1
+
+nodes:
+  done:
+    type: ending
+    outcome: success

--- a/tests/fixtures/workflows/v8_declared_effects_forbidden/input.yaml
+++ b/tests/fixtures/workflows/v8_declared_effects_forbidden/input.yaml
@@ -1,0 +1,19 @@
+name: declared-effects-forbidden
+version: "1.0.0"
+description: Workflow explicitly forbidding two aliases — one declared in data_mcps, one documentation-only.
+
+data_mcps:
+  crm: "internal-crm@^2"
+
+declared_effects:
+  crm: forbidden
+  shell: forbidden
+
+start_node: done
+default_error: done
+
+nodes:
+  done:
+    type: ending
+    outcome: success
+    message: "Done."

--- a/tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml
+++ b/tests/fixtures/workflows/v8_declared_effects_narrow/input.yaml
@@ -1,0 +1,38 @@
+name: declared-effects-narrow
+version: "1.0.0"
+description: Workflow with a narrowed effect envelope — tools subset plus call count cap.
+
+data_mcps:
+  crm: "internal-crm@^2.1"
+  billing: "stripe-mcp@~3"
+
+declared_effects:
+  crm:
+    tools: [search_customers, get_account]
+  billing:
+    tools: [create_invoice]
+    max_call_count: 1
+
+start_node: search
+default_error: error_generic
+
+nodes:
+  search:
+    type: action
+    consequences:
+      - type: mcp_tool_call
+        tool: crm.search_customers
+        params:
+          q: "${computed.query}"
+        store_as: computed.hits
+    on_success: done
+
+  done:
+    type: ending
+    outcome: success
+    message: "Done."
+
+  error_generic:
+    type: ending
+    outcome: error
+    message: "Error."

--- a/tests/fixtures/workflows/v8_declared_effects_unknown_key/input.yaml
+++ b/tests/fixtures/workflows/v8_declared_effects_unknown_key/input.yaml
@@ -1,0 +1,21 @@
+name: declared-effects-unknown-key
+version: "1.0.0"
+description: Forward-compat — unknown keys under an alias object are accepted (reserved for future vocabulary).
+
+data_mcps:
+  crm: "internal-crm@^2"
+
+declared_effects:
+  crm:
+    tools: [search_customers]
+    data_volume_cap_mb: 100
+    time_window_sec: 60
+
+start_node: done
+default_error: done
+
+nodes:
+  done:
+    type: ending
+    outcome: success
+    message: "Done."


### PR DESCRIPTION
## Summary

Adds the optional top-level `declared_effects:` block to the workflow schema, unblocking S3 implementation in hiivmind-blueprint-central. Purely additive — v8.0.0 workflows remain valid under v8.1.0 unchanged.

- Schema: new optional `declared_effects` property on `workflow.json` (draft 2020-12 `oneOf` of `"forbidden"` literal vs structured object with optional `tools` array and `max_call_count` integer); inner `additionalProperties: true` reserves forward-compat keys per S2 §3.4
- Catalog: new `## Declared Effects` section in `blueprint-types.md` parallel to `## Payload Types`
- Example: `## 4. MCP-Delegated Query` in `examples.md` extended to narrow the `eightball` alias to `[shake]` with `max_call_count: 1`
- Fixtures: 3 positive (narrow, forbidden literal, unknown-key forward-compat) + 3 negative (bad value, bad alias name, negative max_call_count)
- Version bump `8.0.0 → 8.1.0`; `schemas.workflow 4.0 → 4.1`; CHANGELOG entry

### Cross-alias validation is runtime, not schema

Cross-alias checks (`tools ⊆ data_mcps.<alias>.tools`, `alias ∈ data_mcps`) are delegated to the consuming runtime, consistent with blueprint-lib's existing type-agnostic posture for `mcp_tool_call`. Schema validates only the syntactic shape.

### Source of truth

S2 spec §3 at hiivmind-blueprint-central commit `c13d65e`. BL6 was PROPOSED in the S1 alignment addendum (lines 261–306); this PR ships it. Post-merge cleanup: flip `PROPOSED` → `SHIPPED` in that addendum.

### Cross-repo sync

A companion PR against `hiivmind-blueprint` (`sync/bl6-declared-effects`) updates `authoring-guide.md` and `execution-guide.md`.

## Test plan

- [ ] Validator is green: `bash scripts/validate-workflows.sh` → 5 positive pass, 5 negative rejected, exit 0
- [ ] `blueprint-types.md` top-level sections grep cleanly in order: Conventions, Nodes, Preconditions, Consequences, Payload Types, Declared Effects
- [ ] `yq -r '.version, .schemas.workflow' package.yaml` → `8.1.0`, `4.1`
- [ ] `examples.md` §4 YAML block parses via `yq`
- [ ] Existing v8.0.0 fixtures (`v8_minimal`, `v8_with_mcp`, the pre-existing negative fixtures) continue to pass/reject correctly